### PR TITLE
Remove scripts from sync.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -89,12 +89,12 @@ group:
       dest: .github/workflows/send-updates.yml
     - source: .github/workflows/test-send-updates.yml
       dest: .github/workflows/test-send-updates.yml
-    - source: scripts/switch_sync_repo.R
-      dest: scripts/switch_sync_repo.R
+    - source: .github/switch_sync_repo.R
+      dest: .github/switch_sync_repo.R
     - source: config_automation.yml
       dest: config_automation.yml
     repos: |
-      jhudsl/OTTR_Quizzes
+      ottrproject/OTTR_Quizzes
 
   - files:
     - source: .github/workflows/

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -14,9 +14,6 @@ group:
           release-notes.yml
           docker-test.yml
           docker-build.yml
-      - source: scripts/
-        dest: scripts/
-        deleteOrphaned: true
       - source: assets/box_images/
         dest: assets/box_images/
       - source: resources/exclude_files.txt
@@ -92,8 +89,6 @@ group:
       dest: .github/workflows/send-updates.yml
     - source: .github/workflows/test-send-updates.yml
       dest: .github/workflows/test-send-updates.yml
-    - source: scripts/make_screenshots.R
-      dest: scripts/make_screenshots.R
     - source: scripts/switch_sync_repo.R
       dest: scripts/switch_sync_repo.R
     - source: config_automation.yml
@@ -121,9 +116,6 @@ group:
       dest: assets/style.css
     - source: assets/toc_close.css
       dest: assets/toc_close.css
-    - source: scripts/
-      dest: scripts/
-      deleteOrphaned: true
     - source: style-sets/fhdasl/
       dest: style-sets/fhdasl/
     - source: config_automation.yml
@@ -147,8 +139,6 @@ group:
       dest: assets/style.css
     - source: assets/toc_close.css
       dest: assets/toc_close.css
-    - source: scripts/
-      dest: scripts/
     - source: config_automation.yml
       dest: config_automation.yml
       deleteOrphaned: true
@@ -165,9 +155,6 @@ group:
       dest: .github/switch_sync_repo.R
     - source: assets/box_images/
       dest: assets/box_images/
-    - source: scripts/
-      dest: scripts/
-      deleteOrphaned: true
     - source: config_automation.yml
       dest: config_automation.yml
     repos: |


### PR DESCRIPTION
OTTR_Template no longer has a scripts directory, and the sync workflow complains about it (see https://github.com/jhudsl/OTTR_Template/actions/runs/12715527505).

This PR removes `/scripts` from the list of files to sync for all repos. This shouldn't cause problems for anyone because `/scripts` is already not being synced (since it doesn't exist).

### Questions

A couple of questions with regards to jhudsl/OTTR_Quizzes:
1. Should this be updated to ottrproject/OTTR_Quizzes?
2. Does it need to sync `switch_sync_repo.R`? Currently it's trying to, but it's looking in `/scripts` and `switch_sync_repo.R` now lives in `.github`.

I would guess yes to both of these and I'm happy to fix them both, but wanted to run it by you before making modification for a repo I'm not very familiar with.

