### PR TITLE
Improve color contrast and make it easier to customize style.

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -19,6 +19,10 @@ group:
         deleteOrphaned: true
       - source: assets/box_images/
         dest: assets/box_images/
+      - source: assets/style.css
+        dest: assets/style.css
+      - source: assets/style_config_default.css
+        dest: assets/style_config_default.css
       - source: resources/exclude_files.txt
         dest: resources/exclude_files.txt
       - source: config_automation.yml
@@ -119,6 +123,8 @@ group:
       dest: assets/box_images/
     - source: assets/style.css
       dest: assets/style.css
+    - source: assets/style_config_default.css
+      dest: assets/style_config_default.css
     - source: assets/toc_close.css
       dest: assets/toc_close.css
     - source: scripts/
@@ -145,6 +151,8 @@ group:
       dest: assets/box_images/
     - source: assets/style.css
       dest: assets/style.css
+    - source: assets/style_config_default.css
+      dest: assets/style_config_default.css
     - source: assets/toc_close.css
       dest: assets/toc_close.css
     - source: scripts/

--- a/_output.yml
+++ b/_output.yml
@@ -1,5 +1,5 @@
 bookdown::gitbook:
-  css: assets/style.css
+  css: [assets/style_config_default.css, assets/style_config_custom.css, assets/style.css]
   includes:
     before_body: assets/big-image.html
     after_body: [assets/footer.html, assets/open-new-tab.html]

--- a/assets/style.css
+++ b/assets/style.css
@@ -46,6 +46,7 @@ pre code {
 
 .book .book-body .page-wrapper .page-inner section.normal a {
   color: var(--link-color);
+  text-decoration: underline;
 }
 
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,7 +1,9 @@
+/* variables are set in style_config_default.css */
+
 @import url('https://fonts.googleapis.com/css?family=Abril+Fatface|Karla:400,400i,700,700i|Lora:400,400i,700,700i&display=swap');
 
 p.caption {
-  color: #777;
+  color: var(--caption-color);
   margin-top: 10px;
 }
 p code {
@@ -43,7 +45,7 @@ pre code {
 /* ------------Links------------------ */
 
 .book .book-body .page-wrapper .page-inner section.normal a {
-  color: #68ace5;
+  color: var(--link-color);
 }
 
 
@@ -71,14 +73,14 @@ h1, h2, h3, h4 {
 .title {
   font-family: 'Lora';
   font-size: 4em !important;
-  color: #012d72;
+  color: var(--accent-color);
   margin-top: 0.275em !important;
   margin-bottom: 0.35em !important;
 }
 
 .subtitle {
   font-family: 'Lora';
-  color: #0b8d96;
+  color: var(--link-color);
 }
 
 
@@ -99,7 +101,7 @@ h1, h2, h3, h4 {
 */
 
 .section.level1 > p:first-of-type:first-letter { /*drop cap for first p beneath level 1 headers only within class .section*/
-  color: #012d72;
+  color: var(--accent-color);
   float: left;
   font-family: 'Abril Fatface', serif;
   font-size: 7em;
@@ -131,14 +133,14 @@ h1, h2, h3, h4 {
 
 
 .book .book-summary {
-  background: white;
+  background: var(--background-color);
   border-right: none;
 }
 
 /*---color of links in TOC----*/
 
 .book .book-summary a {
-color: #012d72
+color: var(--accent-color)
 }
 
 .summary{
@@ -152,17 +154,17 @@ color: #012d72
   padding-bottom: 8px;
   padding-left: 15px;
   padding-right: 15px;
-  color: #012d72;
+  color: var(--accent-color);
 }
 
 .summary a:hover {
-  color: #68ace5 !important;
+  color: var(--highlight-color) !important;
 }
 
 .book .book-summary ul.summary li.active>a { /*active TOC links*/
-  color: #68ace5 !important;
+  color: var(--link-color) !important;
   border-left: solid 4px;
-  border-color: #68ace5;
+  border-color: var(--highlight-color);
   padding-left: 11px !important;
 }
 
@@ -259,11 +261,11 @@ div.notice, div.warning, div.github, div.dictionary, div.reflection, div.wip {
 }
 
 div.notice{
-  border: 4px #68ace5;
+  border: 4px var(--highlight-color);
   border-style: solid;
   background-size: 70px;
   background-position: 15px center;
-  background-color: #e8ebee;
+  background-color: var(--callout-background-color);
   background-image: url("../assets/box_images/note.png");
 }
 
@@ -273,7 +275,7 @@ div.warning{
   border-style: solid;
   background-size: 70px;
   background-position: 15px center;
-  background-color: #e8ebee;
+  background-color: var(--callout-background-color);
   background-image: url("../assets/box_images/warning.png");
 }
 
@@ -282,25 +284,25 @@ div.github{
   border-style: solid;
   background-size: 70px;
   background-position: 15px center;
-  background-color: #e8ebee;
+  background-color: var(--callout-background-color);
   background-image: url("../assets/box_images/github.png");
 }
 
 div.dictionary{
-  border: 4px #68ace5;
+  border: 4px var(--highlight-color);
   border-style: solid;
   background-size: 70px;
   background-position: 15px center;
-  background-color: #e8ebee;
+  background-color: var(--callout-background-color);
   background-image: url("../assets/box_images/dictionary.png");
 }
 
 div.reflection{
-  border: 4px #68ace5;
+  border: 4px var(--highlight-color);
   border-style: solid;
   background-size: 90px;
   background-position: 15px center;
-  background-color: #e8ebee;
+  background-color: var(--callout-background-color);
   background-image: url("../assets/box_images/thinking_face.png");
 }
 
@@ -434,5 +436,5 @@ a.anchor:hover {
 .footer {
   font-family: "Lora", serif;
   font-size: .85em;
-  color: #193a5c;
+  color: var(--accent-color);
 }

--- a/assets/style_config_custom.css
+++ b/assets/style_config_custom.css
@@ -1,0 +1,11 @@
+/*
+any variables listed in style_config_default.css can be overridden by giving them a new value in this file
+- add additional variable on new lines inside the :root element
+- don't forget the semicolon at the end of the line
+*/
+
+:root {
+    --link-color: #0b5b9d;
+    --accent-color: #012d72;
+  }
+

--- a/assets/style_config_default.css
+++ b/assets/style_config_default.css
@@ -1,0 +1,8 @@
+:root {
+    --link-color: #0b5b9d;
+    --accent-color: #012d72;   /* book title, first letter of chapter, toc text */
+    --highlight-color: #68ace5;   /* toc highlight, callout box borders */
+    --caption-color: #595959;
+    --background-color: white;
+    --callout-background-color: #e8ebee;
+  }


### PR DESCRIPTION
### Summary
This PR:
1. updates the default colors used by OTTR to be higher contrast, for conformance with web accessibility guidelines. Also adds an underline to the links, since darkening the link text makes it harder to distinguish from normal text.
2. adds css variables to make it easier to modify the colors used in an OTTR_book
3. Updates sync.yml so repos can receive css updates


### Why
In a UX evaluation of an AnVIL book, it was brought up that the color-contrast for links is insufficient and does not meet web accessibility guidelines. AnVIL uses the same colors as OTTR_Template, so this is also a problem with OTTR.

While working on fixing this, I thought it would be helpful to make it easier for people to change colors of their OTTR books by adding css variables that can be set in one place and referenced throughout `style.css`.



### Details

This is a little convoluted (requires 2 new css files instead of being able to do it in one) in order to support syncing.
1. `style_config_default.css`: This *does* get synced. We need something that can be synced so that, if there's a new variable we want to start using in the main `style.css` file, we can send out the updated `style.css` file without it breaking because the variable hasn't been defined.
2. `style_config_custom.css` gets loaded second, so here people can override anything in `default_style_config.css`. This does not get synced, so they can set the variables to whatever colors they want and not worry about them getting wiped out during syncs.

If this gets merged I can add an explanation to ottrproject.org

Alternatively, if we don't want to support syncing of css, I can just delete `style_config_custom.css`. People will end up with a copy of `style_config_default.css` when they first create a repo from the template, and can modify that if they want. Their changes won't get overwritten if we don't sync the css files.

### Questions:
1. **Are we happy with the new colors?** I just took the existing colors and darkened them a bit until they passed the threshold. 
2. **Are we happy with switching to using css variables?** And are we happy with the set I chose?
3. **Do we want to support syncing the css or not?** Currently we do not. It's useful when OTTR adds new features (like callout boxes), or fixes problems (like accessibility). But if we do it we need to do it in a way that doesn't clobber someone's existing customizations. My solution here was to have two files - one that gets synced (which is read first), and one that doesn't (which, because it's read second will override things in the first file).
  - I do want to at least set up syncing for AnVIL_Template and C-MOOR_Template, because I like getting improvements from OTTR, but if you think that's overly complicated for normal repos I'll take it out of the list of files in the top group of sync.yml.
