### PR TITLE
Update render-all.yml to have a docker image for rendering on main

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -39,8 +39,6 @@ jobs:
     name: Render course preview
     needs: yaml-check
     runs-on: ubuntu-latest
-    container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
 
     steps:
       - name: checkout
@@ -56,6 +54,7 @@ jobs:
           toggle_website: ${{needs.yaml-check.outputs.toggle_website}}
           preview: false
           token: ${{ secrets.GH_PAT }}
+          docker_image: ${{needs.yaml-check.outputs.rendering_docker_image}}
 
   render-tocless:
     name: Render TOC-less version for Leanpub or Coursera


### PR DESCRIPTION
Within multiple repos, we've seen that rendering fails because it deletes the docs folder and has nothing to replace it with (ex: https://github.com/ottrproject/ottrproject.github.io/issues/9). Within the logs there's an error message about not having docker available. However, pull request rendering doesn't have  any of these issues. I created a test repo and have been trying to fix it there -- calling an ottr-preview branch/etc. 

What I discovered is that the render-all file at the beginning of the render step calls the container. However, ottr-preview is expecting a docker_image option (https://github.com/ottrproject/ottr-preview/blob/c3f4ed730cc4a4c0d905014be1abcfefc55bd6b4/action.yml#L78). So this change in the workflow file addresses that and caused successful rendering on main in my test repo: https://github.com/kweav/web_test/tree/main

Notice the change mimics the pull request workflow file and how it passes the docker image to the github action: https://github.com/ottrproject/OTTR_Template/blob/e88e24923ace568182d3e18f49cb3e60994568fb/.github/workflows/pull_request.yml#L152