### PR TITLE
Update sync.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -79,8 +79,8 @@ group:
   - files:
     - source: config_automation.yml
       dest: config_automation.yml
-    - source: .github/workflows/pull-request.yml
-      dest: .github/workflows/pull-request.yml
+    - source: .github/workflows/pull_request.yml
+      dest: .github/workflows/pull_request.yml
     repos: |
       ottrproject/OTTR_Template_Website
 


### PR DESCRIPTION
Latest sync to the ottr template website repo didn't sync my pull request file and from the warning message I noticed it was trying to sync `pull-request.yml` (with a dash) rather than `pull_request.yml` (with an underscore)