### PR TITLE
Update _output.yml to remove new tab default behavior

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -2,7 +2,7 @@ bookdown::gitbook:
   css: [assets/style_config_default.css, assets/style_config_custom.css, assets/style.css]
   includes:
     before_body: assets/big-image.html
-    after_body: [assets/footer.html, assets/open-new-tab.html]
+    after_body: assets/footer.html
     highlight: tango
   config:
     toc:


### PR DESCRIPTION
Want to make it so that the default behavior for bookdown isn't opening every link in a new tab

A related change to ottrpal will make this the default behavior for a no toc rendering (so that coursera links can work with the new plugin): https://github.com/ottrproject/ottrpal/pull/12