### PR TITLE
Upgrade checkout action from v4 to v6

### DIFF
--- a/.github/workflows/check-url.yml
+++ b/.github/workflows/check-url.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
     steps:
     
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Check out current repository
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
 
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/send-updates.yml
+++ b/.github/workflows/send-updates.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login as github actions bot
         run: |

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.repository.name != 'OTTR_Template'
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login as jhudsl-robot
         run: |

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout from Bookdown Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: bookdown
           token: ${{ secrets.GH_PAT }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout code from Leanpub repo
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: quizzes
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}


### PR DESCRIPTION
got an error and PRs were not working on other repos (see https://github.com/ottrproject/cheatsheets/actions/runs/25065495617/job/73431361200), tried updating this and it fixed the issue: https://github.com/ottrproject/cheatsheets/pull/33

So now I am updating the template so that the checkout action is v6